### PR TITLE
Fix release Dockerfile - wrong filename set.

### DIFF
--- a/Docker/Dockerfile.release
+++ b/Docker/Dockerfile.release
@@ -2,7 +2,7 @@ ARG RUNTIME_IMAGE=debian:buster-slim
 
 FROM $RUNTIME_IMAGE as runtime
 
-COPY ./standard-opportunity /usr/local/bin
+COPY ./opportunity-standalone /usr/local/bin
 RUN ldd /usr/local/bin/opportunity-standalone && \
 	/usr/local/bin/opportunity-standalone --version
 


### PR DESCRIPTION
# Fix release Dockerfile - wrong filename set.

## Description

Wrong filename set in release Dockerfile - resulting in pipeline failing.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Thank you for your contribution to Standard Protocol! 🎉
