### PR TITLE
Update oneline.sh

### DIFF
--- a/scripts/oneline.sh
+++ b/scripts/oneline.sh
@@ -74,8 +74,6 @@ ExecStart=/usr/local/bin/opportunity-standalone \
 --base-path $1 \
 --chain opportunity \
 --port 30333 \
---bootnodes /dns/opportunity.standard.tech/tcp/30333/p2p/12D3KooWDPnry4Ei9RxgtY4RfwsM5fnUxg5sXJGbe8LMKrLs8tkf \
-/dns/opportunity2.standard.tech/tcp/30333/p2p/12D3KooWGPAekiLHBHyCYe4x1BAbvSpHYbwkSHk3KxNyoZoyCmp6 \
 --name $2 \
 --validator
 Restart=always


### PR DESCRIPTION
Fix #74

Bootnodes in oneline.sh crash when starting node.
I see that they have already been removed from the documentation.

![image](https://user-images.githubusercontent.com/839118/135664789-0cd094e5-e9ef-41b0-beec-a9e34e1aa44f.png)

- [x] Bug fix (non-breaking change which fixes an issue)
